### PR TITLE
Change nodejs runtime to 8.10 per AWS

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -27,7 +27,7 @@ custom:
   config: ${file(config.yml)}
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs8.10
   stage: ${self:custom.config.stage}
   region: ${self:custom.config.region}
   environment:


### PR DESCRIPTION
When I try to deploy to AWS, I now get an error that nodejs4.3 is no longer supported and to upgrade to 8.10