### PR TITLE
Split IP Whitelists Into Get / Put

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -4,7 +4,13 @@ dynamodb_table_name: ephemera-${self:custom.config.stage}
 region: eu-west-2
 max_secret_age_hours: "24"
 
-# Provide a list of IP addresses to which Ephemera will be restricted (i.e. Your corporate office egress IP)
-# The default of 0.0.0.0/0 permits access from any host on the internet
-whitelisted_ips:
+# IP Restrictions For Ephemera
+# - `add_secret_whitelisted_ips` defines a list of IP Addresses which will be permitted to add secrets to Ephemera (i.e. Your corporate office egress IP(s))
+# - `get_secret_whitelisted_ips` defined a list of IP Addresses which will be permitted to retrieve secrets from Ephemera (i.e. Your corporate office egress / Customer / integration IP(s))
+# The default of 0.0.0.0/0 for both settings permits access from any host on the internet
+add_secret_whitelisted_ips:
   - 0.0.0.0/0
+
+get_secret_whitelisted_ips:
+  - 0.0.0.0/0
+

--- a/serverless.yml
+++ b/serverless.yml
@@ -36,10 +36,17 @@ provider:
       Action: execute-api:Invoke
       Resource:
         - execute-api:/${self:custom.config.stage}/*/addTextSecret
+      Condition:
+        IpAddress:
+          aws:SourceIp: ${self:custom.config.add_secret_whitelisted_ips}
+    - Effect: Allow
+      Principal: "*"
+      Action: execute-api:Invoke
+      Resource:
         - execute-api:/${self:custom.config.stage}/*/getSecret
       Condition:
         IpAddress:
-          aws:SourceIp: ${self:custom.config.whitelisted_ips}
+          aws:SourceIp: ${self:custom.config.get_secret_whitelisted_ips}
   environment:
     REGION: !Ref AWS::Region
     DYNAMODB_TABLE_NAME: ${self:custom.config.dynamodb_table_name}
@@ -144,15 +151,6 @@ resources:
           !Ref S3BucketPublicBucket
         PolicyDocument: 
           Statement: 
-            - 
-              Action: 
-                - "s3:GetObject"
-              Effect: "Deny"
-              Resource: "arn:aws:s3:::${self:custom.config.public_bucket_name}/*"
-              Principal: "*"
-              Condition: 
-                NotIpAddress: 
-                  aws:SourceIp: ${self:custom.config.whitelisted_ips}
             - 
               Action: 
                 - "s3:GetObject"


### PR DESCRIPTION
- Split IP whitelists into one for adding secrets and one for retrieving them
- This enables control over who is able to add data to Ephemera (i.e. Corporate IP's) but enables them to be retrieved from anywhere if required (i.e. By 3rd parties / Customers)